### PR TITLE
Switch the workflow to running MMSeqs2 in bulk

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -11,6 +11,7 @@ os.makedirs("snakemake_tmp", exist_ok=True)
 
 #### Parse sample table ########################################################
 sampletsv = pd.read_csv(config['sampletsv'], sep="\t", index_col=[0])
+sampletsv.index = sampletsv.index.astype(str)
 SAMPLES = sampletsv.index.tolist()
 ################################################################################
 

--- a/workflow/rules/depth.smk
+++ b/workflow/rules/depth.smk
@@ -58,7 +58,8 @@ rule remove_extra_headerlines:
         mem = 4,
         cores = 1
     params:
-        fasta = lambda wildcards: sampletsv.at[wildcards.bin.split("_")[0], 'fastafn']
+        fasta = lambda wildcards: sampletsv.at[wildcards.bin.split("_")[0], 'fastafn'],
+        assembler = config['assembler']
     wrapper:
         "file:workflow/wrappers/remove_extra_headerlines"
 

--- a/workflow/rules/evaluation_maglevel.smk
+++ b/workflow/rules/evaluation_maglevel.smk
@@ -69,7 +69,8 @@ rule remove_extra_headerlines_filtered_contigs:
         mem = 4,
         cores = 1
     params:
-        fasta = lambda wildcards: sampletsv.at[wildcards.bin.split("_")[0], 'fastafn']
+        fasta = lambda wildcards: sampletsv.at[wildcards.bin.split("_")[0], 'fastafn'],
+        assembler = config['assembler']
     wrapper:
         "file:workflow/wrappers/remove_extra_headerlines"
 

--- a/workflow/rules/mmseqs2_gtdb_contigs.smk
+++ b/workflow/rules/mmseqs2_gtdb_contigs.smk
@@ -42,7 +42,8 @@ rule concat_bins:
         mem = 4,
         cores = 1
     params:
-        fas = lambda wildcards: return_bin_fas(wildcards)
+        fas = lambda wildcards: return_bin_fas(wildcards),
+        type = "contigs"
     wrapper:
         "file:workflow/wrappers/concat_bins"
 

--- a/workflow/scripts/identify_kingdom_phylum_contigs.py
+++ b/workflow/scripts/identify_kingdom_phylum_contigs.py
@@ -18,7 +18,7 @@ prokka_contig_names = [name for name, _ in pyfastx.Fasta(f"{snakemake.params.pro
 contig_name_map = {o: p for o, p in zip(original_contig_names, prokka_contig_names)}
 
 # Read MMSeqs2 results
-mmseqs2 = pd.read_csv(snakemake.input[0], sep="\t")
+mmseqs2 = pd.read_csv(snakemake.params.tsv, sep="\t")
 mmseqs2 = mmseqs2.loc[~mmseqs2['lineage'].isnull()]
 
 # Identify most common taxunit and infer path to root

--- a/workflow/wrappers/concat_bins/environment.yaml
+++ b/workflow/wrappers/concat_bins/environment.yaml
@@ -1,0 +1,11 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - python
+  - pip
+  - pandas
+  - pyfastx
+  - pip:
+    - bgzip

--- a/workflow/wrappers/concat_bins/meta.yaml
+++ b/workflow/wrappers/concat_bins/meta.yaml
@@ -1,0 +1,4 @@
+name: "concat_bins"
+description: Concatenate all bins into a single FastA file.
+authors:
+  - Alexander Hübner

--- a/workflow/wrappers/concat_bins/wrapper.py
+++ b/workflow/wrappers/concat_bins/wrapper.py
@@ -7,6 +7,21 @@ import pyfastx
 
 with open(snakemake.output[0], "wt") as outfile:
     for fn in snakemake.params.fas:
-        sample = os.path.basename(os.path.dirname(os.path.dirname(fn)))
-        for name, seq in pyfastx.Fasta(fn, build_index=False):
-            outfile.write(f">{sample}:{name}\n{seq}\n")
+        if snakemake.params.type == "contigs":
+            sample = os.path.basename(os.path.dirname(os.path.dirname(fn)))
+        elif snakemake.params.type == "genes":
+            sample = os.path.basename(fn).replace("-contigs_superkingdom_phylum.fa.gz", "")
+        # Test whether input FastA file is empty
+        if snakemake.params.type == "genes":
+            input_empty = True
+            with open(fn, "rb") as f:
+                fstart = f.read(3)
+                if fstart.startswith(b"\x1f\x8b\x08"):  # gzipped
+                    if os.stat(fn).st_size > 50:
+                        input_empty = False
+                else:
+                    if os.stat(fn).st_size > 0:
+                        input_empty = False
+        if not input_empty or snakemake.params.type == "contigs":
+            for name, seq in pyfastx.Fasta(fn, build_index=False):
+                outfile.write(f">{sample}:{name}\n{seq}\n")

--- a/workflow/wrappers/concat_bins/wrapper.py
+++ b/workflow/wrappers/concat_bins/wrapper.py
@@ -7,13 +7,13 @@ import pyfastx
 
 with open(snakemake.output[0], "wt") as outfile:
     for fn in snakemake.params.fas:
+        input_empty = True
         if snakemake.params.type == "contigs":
             sample = os.path.basename(os.path.dirname(os.path.dirname(fn)))
         elif snakemake.params.type == "genes":
             sample = os.path.basename(fn).replace("-contigs_superkingdom_phylum.fa.gz", "")
         # Test whether input FastA file is empty
         if snakemake.params.type == "genes":
-            input_empty = True
             with open(fn, "rb") as f:
                 fstart = f.read(3)
                 if fstart.startswith(b"\x1f\x8b\x08"):  # gzipped
@@ -22,6 +22,7 @@ with open(snakemake.output[0], "wt") as outfile:
                 else:
                     if os.stat(fn).st_size > 0:
                         input_empty = False
+
         if not input_empty or snakemake.params.type == "contigs":
             for name, seq in pyfastx.Fasta(fn, build_index=False):
                 outfile.write(f">{sample}:{name}\n{seq}\n")

--- a/workflow/wrappers/concat_bins/wrapper.py
+++ b/workflow/wrappers/concat_bins/wrapper.py
@@ -1,0 +1,12 @@
+__author__ = "Alexander Hübner"
+__license__ = "MIT"
+
+import os
+
+import pyfastx
+
+with open(snakemake.output[0], "wt") as outfile:
+    for fn in snakemake.params.fas:
+        sample = os.path.basename(os.path.dirname(os.path.dirname(fn)))
+        for name, seq in pyfastx.Fasta(fn, build_index=False):
+            outfile.write(f">{sample}:{name}\n{seq}\n")

--- a/workflow/wrappers/filter_contigs/wrapper.py
+++ b/workflow/wrappers/filter_contigs/wrapper.py
@@ -31,8 +31,8 @@ prokka_contig_names = [name for name, _ in pyfastx.Fasta(f"{snakemake.params.pro
                                                          build_index=False)]
 contig_name_map = {p: o for o, p in zip(original_contig_names, prokka_contig_names)}
 # Read MMSeqs2 results on gene level
-if os.stat(snakemake.input.genes_mmseqs2).st_size > 0:
-    mmseqs2_genes = pd.read_csv(snakemake.input.genes_mmseqs2, sep="\t")
+if os.stat(snakemake.params.genes_mmseqs2).st_size > 0:
+    mmseqs2_genes = pd.read_csv(snakemake.params.genes_mmseqs2, sep="\t")
     mmseqs2_genes = mmseqs2_genes.loc[~mmseqs2_genes['lineage'].isnull()]
 
 # Filter contigs
@@ -40,7 +40,7 @@ if os.stat(snakemake.input.genes_mmseqs2).st_size > 0:
 contigs_on_path = mmseqs2.loc[((mmseqs2['lineage'].isin(taxpaths)) |
                                (mmseqs2['lineage'].str.contains(taxpaths[-1])))]
 ## 2. Remove contigs with genes from different organisms - chimeric contigs
-if os.stat(snakemake.input.genes_mmseqs2).st_size > 0:
+if os.stat(snakemake.params.genes_mmseqs2).st_size > 0:
     gff['contig'] = gff['attribute'].str.split(";").str[0].str.replace("ID=", "")
     mmseqs2_genes = mmseqs2_genes.merge(gff[['seqname', 'contig']], how="left", on="contig")
     mmseqs2_genes['consensus_lineage'] = mmseqs2_genes['lineage'].isin(taxpaths)

--- a/workflow/wrappers/filter_contigs/wrapper.py
+++ b/workflow/wrappers/filter_contigs/wrapper.py
@@ -60,6 +60,7 @@ cofgs_cov_avg = contigs_on_path.loc[contigs_on_path['cofgs']]['Depth median'].me
 cofgs_cov_std = contigs_on_path.loc[contigs_on_path['cofgs']]['Depth median'].std()
 contigs_on_path['depth_filter'] = (contigs_on_path.loc[~contigs_on_path['cofgs']]['Depth median'] - cofgs_cov_avg).abs() < (2 * cofgs_cov_std)
 contigs_on_path['depth_filter'] = contigs_on_path['depth_filter'].fillna(value=True)
+contigs_on_path = contigs_on_path.drop(['Contig'], axis=1)
 
 # Generate final list of contigs
 contigs = set(contigs_on_path.loc[contigs_on_path['depth_filter'],

--- a/workflow/wrappers/filter_contigs/wrapper.py
+++ b/workflow/wrappers/filter_contigs/wrapper.py
@@ -10,7 +10,7 @@ import pyfastx
 # Read coverage
 coverage = pd.read_csv(snakemake.input.depth, sep="\t")
 # Read MMSeqs2 GTDB assignments on contig level
-mmseqs2 = pd.read_csv(snakemake.input.contigs_mmseqs2, sep="\t")
+mmseqs2 = pd.read_csv(snakemake.params.contigs_mmseqs2, sep="\t")
 mmseqs2 = mmseqs2.loc[~mmseqs2['lineage'].isnull()]
 
 # Identify most common taxunit and infer path to root

--- a/workflow/wrappers/mmseqs2_createdb/wrapper.py
+++ b/workflow/wrappers/mmseqs2_createdb/wrapper.py
@@ -1,25 +1,8 @@
 __author__ = "Alexander Hübner"
 __license__ = "MIT"
 
-import os
-from pathlib import Path
-
 from snakemake.shell import shell
 
-# Test whether input FastA file is empty
-input_empty = True
-with open(snakemake.input[0], "rb") as f:
-    fstart = f.read(3)
-    if fstart.startswith(b"\x1f\x8b\x08"):  # gzipped
-        if os.stat(snakemake.input[0]).st_size > 50:
-            input_empty = False
-    else:
-        if os.stat(snakemake.input[0]).st_size > 0:
-            input_empty = False
-
-if not input_empty:
-    shell(
-        "(mmseqs createdb {snakemake.input[0]} {snakemake.output[0]})"
-    )
-else:
-    Path(snakemake.output[0]).touch()
+shell(
+    "(mmseqs createdb {snakemake.input[0]} {snakemake.output[0]})"
+)

--- a/workflow/wrappers/mmseqs2_createdb/wrapper.py
+++ b/workflow/wrappers/mmseqs2_createdb/wrapper.py
@@ -8,18 +8,18 @@ from snakemake.shell import shell
 
 # Test whether input FastA file is empty
 input_empty = True
-with open(snakemake.params.fa, "rb") as f:
+with open(snakemake.input[0], "rb") as f:
     fstart = f.read(3)
     if fstart.startswith(b"\x1f\x8b\x08"):  # gzipped
-        if os.stat(snakemake.params.fa).st_size > 50:
+        if os.stat(snakemake.input[0]).st_size > 50:
             input_empty = False
     else:
-        if os.stat(snakemake.params.fa).st_size > 0:
+        if os.stat(snakemake.input[0]).st_size > 0:
             input_empty = False
 
 if not input_empty:
     shell(
-        "(mmseqs createdb {snakemake.params.fa} {snakemake.output[0]})"
+        "(mmseqs createdb {snakemake.input[0]} {snakemake.output[0]})"
     )
 else:
     Path(snakemake.output[0]).touch()

--- a/workflow/wrappers/mmseqs2_splittsv/environment.yaml
+++ b/workflow/wrappers/mmseqs2_splittsv/environment.yaml
@@ -1,0 +1,11 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - python
+  - pip
+  - pandas
+  - pyfastx
+  - pip:
+    - bgzip

--- a/workflow/wrappers/mmseqs2_splittsv/meta.yaml
+++ b/workflow/wrappers/mmseqs2_splittsv/meta.yaml
@@ -1,0 +1,4 @@
+name: "mmseqs2_splittsv"
+description: Split the MMSeqs2 results TSV into individual ones per bin.
+authors:
+  - Alexander Hübner

--- a/workflow/wrappers/mmseqs2_splittsv/wrapper.py
+++ b/workflow/wrappers/mmseqs2_splittsv/wrapper.py
@@ -12,6 +12,7 @@ mmseqs2['contig'] = mmseqs2['contig'].str.split(":").str[1]
 
 # Import sample TSV
 sampletsv = pd.read_csv(snakemake.params.sampletsv, sep="\t", index_col=[0])
+sampletsv.index = sampletsv.index.astype(str)
 
 for sample in mmseqs2['sample'].unique():
     # Load overview list of bins
@@ -23,7 +24,6 @@ for sample in mmseqs2['sample'].unique():
     contigs = pd.read_csv(sampletsv.at[sample, 'metawrapreport'].replace(".stats", ".contigs"),
                           sep="\t", header=None, names=['contig', 'bin'], index_col=['bin'])
     for b in sample_bins.index:
-        print(b)
         c = contigs.loc[sample_bins.at[b, 'bin']]['contig'].tolist()
         mmseqs2.loc[(mmseqs2['sample'] == sample) & (mmseqs2['contig'].isin(c))] \
             .drop(['sample'], axis=1) \

--- a/workflow/wrappers/mmseqs2_splittsv/wrapper.py
+++ b/workflow/wrappers/mmseqs2_splittsv/wrapper.py
@@ -1,0 +1,30 @@
+__author__ = "Alexander Hübner"
+__license__ = "MIT"
+
+import os
+
+import pandas as pd
+
+# Import MMSeqs2 results
+mmseqs2 = pd.read_csv(snakemake.input[0], sep="\t")
+mmseqs2['sample'] = mmseqs2['contig'].str.split(":").str[0]
+mmseqs2['contig'] = mmseqs2['contig'].str.split(":").str[1]
+
+# Import sample TSV
+sampletsv = pd.read_csv(snakemake.params.sampletsv, sep="\t", index_col=[0])
+
+for sample in mmseqs2['sample'].unique():
+    # Load overview list of bins
+    sample_bins = pd.read_csv(sampletsv.at[sample, 'metawrapreport'], sep="\t")
+    sample_bins['binid'] = sample_bins['bin'].str.extract(r'bin.([0-9]+)$').astype(int)
+    sample_bins['sample_binID'] = [f"{sample}_{i:03}" for i in sample_bins['binid']]
+    sample_bins = sample_bins.set_index(['sample_binID'])
+    # Load map of contigs per bin
+    contigs = pd.read_csv(sampletsv.at[sample, 'metawrapreport'].replace(".stats", ".contigs"),
+                          sep="\t", header=None, names=['contig', 'bin'], index_col=['bin'])
+    for b in sample_bins.index:
+        print(b)
+        c = contigs.loc[sample_bins.at[b, 'bin']]['contig'].tolist()
+        mmseqs2.loc[(mmseqs2['sample'] == sample) & (mmseqs2['contig'].isin(c))] \
+            .drop(['sample'], axis=1) \
+            .to_csv(f"{snakemake.params.dir}/{b}.mmseqs2_gtdb.annot.tsv", sep="\t", index=False)

--- a/workflow/wrappers/mmseqs2_splittsv_genes/environment.yaml
+++ b/workflow/wrappers/mmseqs2_splittsv_genes/environment.yaml
@@ -1,0 +1,11 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - python
+  - pip
+  - pandas
+  - pyfastx
+  - pip:
+    - bgzip

--- a/workflow/wrappers/mmseqs2_splittsv_genes/meta.yaml
+++ b/workflow/wrappers/mmseqs2_splittsv_genes/meta.yaml
@@ -1,0 +1,4 @@
+name: "mmseqs2_splittsv_genes"
+description: Split the MMSeqs2 results TSV into individual ones per bin.
+authors:
+  - Alexander Hübner

--- a/workflow/wrappers/mmseqs2_splittsv_genes/wrapper.py
+++ b/workflow/wrappers/mmseqs2_splittsv_genes/wrapper.py
@@ -1,0 +1,33 @@
+__author__ = "Alexander Hübner"
+__license__ = "MIT"
+
+import os
+from pathlib import Path
+
+import pandas as pd
+
+# Import MMSeqs2 results
+mmseqs2 = pd.read_csv(snakemake.input[0], sep="\t")
+mmseqs2['sample_binID'] = mmseqs2['contig'].str.split(":").str[0]
+mmseqs2['sample'] = mmseqs2['sample_binID'].str.split("_").str[0]
+mmseqs2['contig'] = mmseqs2['contig'].str.split(":").str[1]
+
+# Generate list of all expected bins
+sampletsv = pd.read_csv(snakemake.params.sampletsv, sep="\t", index_col=[0])
+expected_bins = []
+for sample in sampletsv.index:
+    # Load overview list of bins
+    sample_bins = pd.read_csv(sampletsv.at[sample, 'metawrapreport'], sep="\t")
+    sample_bins['binid'] = sample_bins['bin'].str.extract(r'bin.([0-9]+)$').astype(int)
+    sample_bins['sample_binID'] = [f"{sample}_{i:03}" for i in sample_bins['binid']]
+    expected_bins.extend(sample_bins['sample_binID'].tolist())
+
+# Iterate overall bins: if genes were screened, export results, others create
+# an empty file
+for binid in expected_bins:
+    if binid in mmseqs2['sample_binID'].tolist():
+        mmseqs2.loc[mmseqs2['sample_binID'] == binid] \
+            .drop(['sample_binID'], axis=1) \
+            .to_csv(f"{snakemake.params.dir}/{binid}.mmseqs2_gtdb.annot.tsv", sep="\t", index=False)
+    else:
+        Path(f"{snakemake.params.dir}/{binid}.mmseqs2_gtdb.annot.tsv").touch()

--- a/workflow/wrappers/remove_extra_headerlines/wrapper.py
+++ b/workflow/wrappers/remove_extra_headerlines/wrapper.py
@@ -11,7 +11,10 @@ bamfile = pysam.AlignmentFile(snakemake.input.bam)
 header = bamfile.header
 
 # Generate subset of SQ tags from contig list
-extract_sn_ln = re.compile(r'(k[0-9]+_[0-9]+):1-([0-9]+)')
+if snakemake.params.assembler == "megahit":
+    extract_sn_ln = re.compile(r'(k[0-9]+_[0-9]+):1-([0-9]+)')
+elif snakemake.params.assembler == "metaspades":
+    extract_sn_ln = re.compile(r'(NODE_[0-9]+_length_[0-9]+_cov_[0-9]+.*[0-9*]):1-([0-9]+)')
 with open(snakemake.input.contiglist, "rt") as contigfile:
     sq_info = [extract_sn_ln.search(line.rstrip()).groups()
                for line in contigfile]


### PR DESCRIPTION
Running MMSeqs2 in bulk on all contigs at once is much faster than running it per bin because the samples are very similar and the database search has to be only be done a single time. Therefore, I re-implemented the two MMSeqs2 searches against the GTDB to run in bulk mode.
